### PR TITLE
Added option to disable continuous-sliding

### DIFF
--- a/jquery.touchslider.js
+++ b/jquery.touchslider.js
@@ -29,7 +29,8 @@ http://touchslider.com
 				pagination: "." + namespace + "-nav-item",
 				currentClass: namespace + "-nav-item-current",
 				duration: 350,
-				mouseTouch: true
+				mouseTouch: true,
+				continuous: true
 				// [container, scroller]
 			}, options);
 
@@ -119,9 +120,11 @@ http://touchslider.com
 				to: function(toIndex, opt) {
 					opt = opt || {};
 					if (toIndex >= slides.length) {
-						toIndex = 0;
+						if(options.continuous){ toIndex = 0; }
+						else { return false; }
 					} else if (toIndex < 0){
-						toIndex = slides.length - 1;
+						if(options.continuous){ toIndex = slides.length - 1; }
+						else { return false; }
 					}
 					var duration = options.duration,
 						node = slides.eq(toIndex),

--- a/jquery.touchslider.js
+++ b/jquery.touchslider.js
@@ -120,11 +120,17 @@ http://touchslider.com
 				to: function(toIndex, opt) {
 					opt = opt || {};
 					if (toIndex >= slides.length) {
-						if(options.continuous){ toIndex = 0; }
-						else { return false; }
+						if(options.continuous){
+							toIndex = 0;
+						} else { 
+							return false; 
+						}
 					} else if (toIndex < 0){
-						if(options.continuous){ toIndex = slides.length - 1; }
-						else { return false; }
+						if(options.continuous){
+							toIndex = slides.length - 1;
+						} else { 
+							return false; 
+						}
 					}
 					var duration = options.duration,
 						node = slides.eq(toIndex),


### PR DESCRIPTION
Now it is possible to set continuous to false to make sure the slider stops at the last slide, instead of loading the first slide again.
