### PR TITLE
jquery 1.9 support

### DIFF
--- a/jquery.touchslider.js
+++ b/jquery.touchslider.js
@@ -573,7 +573,7 @@ http://touchslider.com
 							return;
 						}
 
-						if ($.browser.msie) {
+						if (/msie/.test(navigator.userAgent.toLowerCase())) {
 							e.preventDefault();
 						}
 					}


### PR DESCRIPTION
Added support for jquery 1.9: the browser object was deprecated in jquery in v1.3, removed in v1.9.
